### PR TITLE
Update MySQL image to use mariadb

### DIFF
--- a/wordpress-deployment-chart/wp-chart/templates/mysql-deployment.yaml
+++ b/wordpress-deployment-chart/wp-chart/templates/mysql-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql@sha256:897086d07d1efa876224b147397ea8d3147e61dd84dce963aace1d5e9dc2802d
+      - image: mariadb:10.6
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD

--- a/wordpress-deployment-chart/wp-chart/templates/mysql-deployment.yaml
+++ b/wordpress-deployment-chart/wp-chart/templates/mysql-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql@sha256:897086d07d1efa876224b147397ea8d3147e61dd84dce963aace1d5e9dc2802d
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
Since the official mysql 5.6 docker image is no longer maintained, we have to use the specific SHA256 digest for this archived version of mysql 5.6 image. With this change, the mysql pod image pull will no longer throw an error